### PR TITLE
Drop automerge-flathubbot-prs

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
It's only for verified apps, and LibreSprite isn't verified, so the linter complains.

Hopefully this should fix the error in the *Validate manifet* stage here: https://buildbot.flathub.org/#/builders/19/builds/18185.
```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions manifest com.github.libresprite.LibreSprite.yaml
 in dir /srv/buildbot/worker/build-x86_64-1/build (timeout 1200 secs)
 watching logfiles {}
 argv: b'flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions manifest com.github.libresprite.LibreSprite.yaml'
 using PTY: False
{
    "errors": [
        "flathub-json-automerge-enabled"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
program finished with exit code 1
elapsedTime=8.629015
```