### PR TITLE
Enable wayland backend

### DIFF
--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -7,8 +7,7 @@ rename-appdata-file: libresprite.appdata.xml
 rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:
-  - --socket=x11
-  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   - --filesystem=home

--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -8,6 +8,7 @@ rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:
   - --socket=x11
+  - --socket=wayland
   - --share=ipc
   - --device=dri
   - --filesystem=home

--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -7,6 +7,7 @@ rename-appdata-file: libresprite.appdata.xml
 rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:
+  - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri


### PR DESCRIPTION
The flatpak pkg has up-to-date SDL unlike the AppImage.

Related issue:
https://github.com/LibreSprite/LibreSprite/issues/453