### PR TITLE
Disable automerge-flathubbot-prs

### DIFF
--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: libresprite
-rename-appdata-file: libresprite.appdata.xml
+rename-appdata-file: io.github.libresprite.libresprite.metainfo.xml
 rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:

--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.libresprite.LibreSprite
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: libresprite
 rename-appdata-file: io.github.libresprite.libresprite.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "automerge-flathubbot-prs": true
+    "automerge-flathubbot-prs": false
 }


### PR DESCRIPTION
Since this app is not verified on FlatHub, automerge-flathubbot-prs cannot be enabled and raises a linter error.

This should hopefully prevent the builds in PRs from failing.