### PR TITLE
update platform and dependencies

### DIFF
--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -1,13 +1,14 @@
 app-id: com.github.libresprite.LibreSprite
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: libresprite
 rename-appdata-file: libresprite.appdata.xml
 rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --device=dri
   - --filesystem=home
@@ -16,30 +17,23 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-        sha256: 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+        url: https://github.com/google/googletest/archive/refs/tags/v1.16.0.tar.gz
+        sha256: 78c676fc63881529bf97bf9d45948d905a66833fbfa5318ea2cd7478cb98f399
         x-checker-data:
           type: anitya
           project-id: 18290
           url-template: https://github.com/google/googletest/archive/refs/tags/v$version.tar.gz
-
-# LibreSprite fails to build with upstream tinyxml
-# module copied from https://github.com/flathub/tv.kodi.Kodi/blob/master/modules/tinyxml/tinyxml.json
-  - name: tinyxml
     cleanup:
-      - /include
-      - /share/doc
-      - '*.a'
-      - '*.la'
-      - /lib/*.so
+      - '*'
+
+  - name: tinyxml
+    buildsystem: cmake
     sources:
-      - type: archive
-        url: http://mirrors.kodi.tv/build-deps/sources/tinyxml-2.6.2_2.tar.gz
-        sha256: 8164c9ad48b9028667768a584d62f7760cfbfb90d0dd6214ad174403058da10c
-      - type: script
-        dest-filename: autogen.sh
-        commands:
-          - autoreconf -vfi
+      - type: git
+        url: https://github.com/leethomason/tinyxml2.git
+        tag: 11.0.0
+    cleanup:
+      - '*'
 
   - name: libresprite
     buildsystem: cmake-ninja
@@ -51,11 +45,12 @@ modules:
   # use git, so that submodules don't have to be added as sources to the module
       - type: git
         url: https://github.com/LibreSprite/LibreSprite
-        commit: 4dac17fd198288d91c07592373449dcdddaf7e24
+        commit: dce8cfe7b6d366fe0ae8f3b35740c0f9e2e4d9e0
         x-checker-data:
           type: anitya
           project-id: 153525
           tag-template: v$version
           stable-only: true
+        tag: v1.1
     post-install:
       - install -Dm644 /app/share/libresprite/data/icons/ase64.png /app/share/icons/hicolor/64x64/apps/libresprite.png

--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -27,7 +27,7 @@ modules:
       - '*'
 
   - name: tinyxml
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://github.com/leethomason/tinyxml2.git

--- a/com.github.libresprite.LibreSprite.yaml
+++ b/com.github.libresprite.LibreSprite.yaml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: libresprite
-rename-appdata-file: libresprite.appdata.xml
+rename-appdata-file: io.github.libresprite.libresprite.metainfo.xml
 rename-desktop-file: libresprite.desktop
 rename-icon: libresprite
 finish-args:
@@ -52,5 +52,11 @@ modules:
           tag-template: v$version
           stable-only: true
         tag: v1.1
+
+        # LibreSprite-provided meta does not currently contain developer information
+        # Until it does, we provide a version with developer information added
+      - type: patch
+        path: patches/com.github.libresprite.libresprite.metainfo.xml.patch
     post-install:
       - install -Dm644 /app/share/libresprite/data/icons/ase64.png /app/share/icons/hicolor/64x64/apps/libresprite.png
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,2 @@
 {
-    "automerge-flathubbot-prs": true
 }

--- a/patches/com.github.libresprite.libresprite.metainfo.xml.patch
+++ b/patches/com.github.libresprite.libresprite.metainfo.xml.patch
@@ -1,0 +1,14 @@
+diff --git a/desktop/io.github.libresprite.libresprite.metainfo.xml b/desktop/io.github.libresprite.libresprite.metainfo.xml
+index cdb507fff..28af1c496 100644
+--- a/desktop/io.github.libresprite.libresprite.metainfo.xml
++++ b/desktop/io.github.libresprite.libresprite.metainfo.xml
+@@ -19,6 +19,9 @@
+ 		<li>Several file types supported for your sprites and animations</li>
+ 		</ul>
+ 	</description>
++	<developer id="com.github.libresprite">
++		<name>LibreSprite Developers</name>
++	</developer>
+ 	<url type="homepage">https://libresprite.github.io</url>
+ 	<url type="bugtracker">https://github.com/LibreSprite/LibreSprite/issues/</url>
+ 	<url type="vcs-browser">https://github.com/LibreSprite/LibreSprite/</url>


### PR DESCRIPTION
This commit updates the dependencies for LibreSprite to bring the flatpak up to a modern platform version.

The changes are as follows:
* Update gtest to the latest version and remove gtest artifacts from the final build
* Eliminate the dependency on a Kodi mirror of tinyxml. At some point tinyxml didn't work with the upstream version, but this probably hasn't been the case for a long time.
* Update LibreSprite from v1.1-dev to the actual tag v1.1 release. It's worth pointing out there's a 1.2 pre-release out, but I did not update to that here.
* Enable wayland to close issue #33.

I understand that LibreSprite is basically in maintenance mode, but these are just tiny things that keep it building and up to date without much effort.